### PR TITLE
.github: workflow: use minimal defconfig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Set configuration
       run: |
-        ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- make imx_v8_defconfig
+        ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- make imx93frdm_defconfig
 
     - name: Build kernel
       run: |


### PR DESCRIPTION
Building the kernel with imx_v8_defconfig takes a lot of time in the GH CI (1h30) so switch to a more lightweight defconfig