### PR TITLE
drivers: lkss: add initial LKSS lab driver framework

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -247,4 +247,6 @@ source "drivers/cdx/Kconfig"
 
 source "drivers/dpll/Kconfig"
 
+source "drivers/lkss/Kconfig"
+
 endmenu

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -10,6 +10,8 @@ obj-y				+= cache/
 obj-y				+= irqchip/
 obj-y				+= bus/
 
+obj-$(CONFIG_LKSS_DRIVERS)	+= lkss/
+
 obj-$(CONFIG_GENERIC_PHY)	+= phy/
 
 # GPIO must come after pinctrl as gpios may need to mux pins etc

--- a/drivers/lkss/Kconfig
+++ b/drivers/lkss/Kconfig
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+menuconfig LKSS_DRIVERS
+	bool "Linux Kernel Summer School drivers"
+	default n
+	help
+	  Enable support for Linux Kernel Summer School drivers.
+
+if LKSS_DRIVERS
+
+config LKSS_DRIVERS_LAB1
+        tristate "Linux Kernel Summer School lab 1 drivers"
+        default n
+        help
+          Enable support for lab 1 drivers.
+
+source "drivers/lkss/lab1/Kconfig"
+
+config LKSS_DRIVERS_LAB2
+	tristate "Linux Kernel Summer School lab 2 drivers"
+	default n
+	help
+	  Enable support for lab 2 drivers.
+
+source "drivers/lkss/lab2/Kconfig"
+
+config LKSS_DRIVERS_LAB3
+        tristate "Linux Kernel Summer School lab 3 drivers"
+        default n
+        help
+          Enable support for lab 3 drivers.
+
+source "drivers/lkss/lab3/Kconfig"
+
+config LKSS_DRIVERS_LAB4
+        tristate "Linux Kernel Summer School lab 4 drivers"
+        default n
+        help
+          Enable support for lab 4 drivers.
+
+source "drivers/lkss/lab4/Kconfig"
+
+endif # LKSS_DRIVERS

--- a/drivers/lkss/Makefile
+++ b/drivers/lkss/Makefile
@@ -1,0 +1,4 @@
+obj-$(CONFIG_LKSS_DRIVERS_LAB1)	+= lab1/
+obj-$(CONFIG_LKSS_DRIVERS_LAB2)	+= lab2/
+obj-$(CONFIG_LKSS_DRIVERS_LAB3) += lab3/
+obj-$(CONFIG_LKSS_DRIVERS_LAB4) += lab4/

--- a/drivers/lkss/lab1/Kconfig
+++ b/drivers/lkss/lab1/Kconfig
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+if LKSS_DRIVERS_LAB1
+endif # LKSS_DRIVERS_LAB1

--- a/drivers/lkss/lab1/Makefile
+++ b/drivers/lkss/lab1/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0
+
+obj-$(CONFIG_LKSS_DRIVERS_LAB1)	+= ex1/hello.o

--- a/drivers/lkss/lab1/ex1/hello.c
+++ b/drivers/lkss/lab1/ex1/hello.c
@@ -1,0 +1,18 @@
+#include <linux/init.h>
+#include <linux/module.h>
+
+static int __init hello_init(void) {
+    printk(KERN_INFO "Hello from kernel space!\n");
+    return 0;
+}
+
+static void __exit hello_exit(void) {
+    printk(KERN_INFO "Goodbye from kernel space!\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Lab1");
+MODULE_DESCRIPTION("Hello World Kernel Module");

--- a/drivers/lkss/lab2/Kconfig
+++ b/drivers/lkss/lab2/Kconfig
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+if LKSS_DRIVERS_LAB2
+endif # LKSS_DRIVERS_LAB2

--- a/drivers/lkss/lab3/Kconfig
+++ b/drivers/lkss/lab3/Kconfig
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+if LKSS_DRIVERS_LAB3
+endif # LKSS_DRIVERS_LAB3

--- a/drivers/lkss/lab4/Kconfig
+++ b/drivers/lkss/lab4/Kconfig
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+if LKSS_DRIVERS_LAB4
+endif # LKSS_DRIVERS_LAB4


### PR DESCRIPTION
Set up basic infrastructure for Linux Kernel Summer School labs, including Kconfig, Makefiles, and a simple hello world module for lab1.