### PR TITLE
lkss: dts: Mark dts nodes as "disbled" by default.

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx93-11x11-frdm.dts
+++ b/arch/arm64/boot/dts/freescale/imx93-11x11-frdm.dts
@@ -35,7 +35,7 @@
 		button {
 			compatible = "lkss,gpio-button";
 			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>; // Example: GPIO2.IO[3]
-			status = "okay";
+			status = "disabled";
 		};
 
 		button-led {
@@ -43,14 +43,14 @@
 			button-gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;// Example: GPIO2.IO[3]
 			led-gpios = <&gpio2 4 GPIO_ACTIVE_HIGH>; // Example: GPIO2.IO[4]
 
-			status = "okay";
+			status = "disabled";
 		};
 
 		button-semaphore {
 			compatible = "lkss,gpio-button-semaphore";
 			/* TODO: Add button and led GPIOs */
 
-			status = "okay";
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
This is the way they should be and also prevents loading unwanted drivers.