### PR TITLE
imx93-11x11-frdm.dts: Add lkss-device node

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx93-11x11-frdm.dts
+++ b/arch/arm64/boot/dts/freescale/imx93-11x11-frdm.dts
@@ -32,6 +32,14 @@
 	lkss-bus {
 		compatible = "simple-bus";
 
+		lkss-device {
+			compatible = "lkss,my-lkss-device";
+			myint = <42>;
+			mystring = "hello";
+
+			status = "disabled";
+		};
+
 		button {
 			compatible = "lkss,gpio-button";
 			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>; // Example: GPIO2.IO[3]


### PR DESCRIPTION
This is to be used for lab1 ex4.